### PR TITLE
fix: rewrite download_file in plugin API

### DIFF
--- a/src/plugin/interface/network.rs
+++ b/src/plugin/interface/network.rs
@@ -1,27 +1,51 @@
-use std::{io::Cursor, path::PathBuf};
+use std::fs::File;
+use std::io::copy;
+use std::path::PathBuf;
 
-use mlua::UserData;
+use mlua::{UserData, Result, Error, UserDataMethods};
+
+use reqwest::Url;
+use tokio::task;
+use log::{error, info};
 
 pub struct PluginNetwork;
 impl UserData for PluginNetwork {
-    fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
-        methods.add_function("download_file", |_, args: (String, String)| {
-            let url = args.0;
-            let path = args.1;
-
-            let resp = reqwest::blocking::get(url);
-            if let Ok(resp) = resp {
-                let mut content = Cursor::new(resp.bytes().unwrap());
-                let file = std::fs::File::create(PathBuf::from(path));
-                if file.is_err() {
-                    return Ok(false);
-                }
-                let mut file = file.unwrap();
-                let res = std::io::copy(&mut content, &mut file);
-                return Ok(res.is_ok());
-            }
-
-            Ok(false)
+    fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_function("download_file", |_, (url, path): (String, String)| {
+            download_file(url, path)
         });
     }
+}
+
+fn download_file(url: String, path: String) -> Result<()> {
+    let new_url = Url::parse(&url).map_err(|e| Error::external(e))?;
+    let path = PathBuf::from(&path);
+
+    task::block_in_place(|| {
+        let mut response = match reqwest::blocking::get(new_url) {
+            Ok(response) => response,
+            Err(e) => {
+                error!("Failed to download file from URL '{}': {}", url, e);
+                return Err(Error::external(e));
+            }
+        };
+        if !response.status().is_success() {
+            let status = response.status();
+            error!("Failed to download file from URL '{}': status {}", url, status);
+            return Err(Error::external(format!("Failed to download file: status {}", status)));
+        }
+        let mut dest = match File::create(&path) {
+            Ok(file) => file,
+            Err(e) => {
+                error!("Failed to create file at path '{}': {}", path.display(), e);
+                return Err(Error::external(e));
+            }
+        };
+        if let Err(e) = copy(&mut response, &mut dest) {
+            error!("Failed to write data to file at path '{}': {}", path.display(), e);
+            return Err(Error::external(e));
+        }
+        info!("Downloaded file from URL '{}' to path '{}'", url, path.display());
+        Ok(())
+    })
 }

--- a/src/plugin/interface/network.rs
+++ b/src/plugin/interface/network.rs
@@ -2,50 +2,57 @@ use std::fs::File;
 use std::io::copy;
 use std::path::PathBuf;
 
-use mlua::{UserData, Result, Error, UserDataMethods};
+use mlua::{Error, UserData, UserDataMethods};
 
+use log::{error, info};
 use reqwest::Url;
 use tokio::task;
-use log::{error, info};
 
 pub struct PluginNetwork;
 impl UserData for PluginNetwork {
     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
         methods.add_function("download_file", |_, (url, path): (String, String)| {
-            download_file(url, path)
+            let new_url = Url::parse(&url).map_err(Error::external)?;
+            let path = PathBuf::from(&path);
+
+            task::block_in_place(|| {
+                let mut response = match reqwest::blocking::get(new_url) {
+                    Ok(response) => response,
+                    Err(e) => {
+                        error!("Failed to download file from URL '{}': {}", url, e);
+                        return Ok(false);
+                    }
+                };
+                if !response.status().is_success() {
+                    let status = response.status();
+                    error!(
+                        "Failed to download file from URL '{}': status {}",
+                        url, status
+                    );
+                    return Ok(false);
+                }
+                let mut dest = match File::create(&path) {
+                    Ok(file) => file,
+                    Err(e) => {
+                        error!("Failed to create file at path '{}': {}", path.display(), e);
+                        return Ok(false);
+                    }
+                };
+                if let Err(e) = copy(&mut response, &mut dest) {
+                    error!(
+                        "Failed to write data to file at path '{}': {}",
+                        path.display(),
+                        e
+                    );
+                    return Ok(false);
+                }
+                info!(
+                    "Downloaded file from URL '{}' to path '{}'",
+                    url,
+                    path.display()
+                );
+                Ok(true)
+            })
         });
     }
-}
-
-fn download_file(url: String, path: String) -> Result<()> {
-    let new_url = Url::parse(&url).map_err(|e| Error::external(e))?;
-    let path = PathBuf::from(&path);
-
-    task::block_in_place(|| {
-        let mut response = match reqwest::blocking::get(new_url) {
-            Ok(response) => response,
-            Err(e) => {
-                error!("Failed to download file from URL '{}': {}", url, e);
-                return Err(Error::external(e));
-            }
-        };
-        if !response.status().is_success() {
-            let status = response.status();
-            error!("Failed to download file from URL '{}': status {}", url, status);
-            return Err(Error::external(format!("Failed to download file: status {}", status)));
-        }
-        let mut dest = match File::create(&path) {
-            Ok(file) => file,
-            Err(e) => {
-                error!("Failed to create file at path '{}': {}", path.display(), e);
-                return Err(Error::external(e));
-            }
-        };
-        if let Err(e) = copy(&mut response, &mut dest) {
-            error!("Failed to write data to file at path '{}': {}", path.display(), e);
-            return Err(Error::external(e));
-        }
-        info!("Downloaded file from URL '{}' to path '{}'", url, path.display());
-        Ok(())
-    })
 }


### PR DESCRIPTION
This fixes a panic in the plugin system when downloading files. Now the function properly notifies tokio that it will block the thread, and also has some logging and error handling so we can easily debug download issues.