### PR TITLE
fix: properly load library_dir

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -96,7 +96,9 @@ impl PluginManager {
         lua.globals().set("config_info", config.clone())?;
 
         // auto-load library_dir
-        let library_dir = plugin_dir.join("core").to_str().unwrap();
+        let core_path = plugin_dir.join("core");
+        let library_dir = core_path.to_str().unwrap();
+        lua.globals().set("library_dir", library_dir)?;
         lua.load(chunk!(package.path = $library_dir.."/?.lua"))
             .exec()?;
 


### PR DESCRIPTION
Commit a95537 currently makes the CLI not compile. Fixing the error however leads to a crash when initializing plugins because library_dir isn't available inside the Lua files. I set library_dir as a global before setting package.path. This fixes the issue and plugins now load successfully.