### PR TITLE
fix: properly load library_dir

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -96,7 +96,8 @@ impl PluginManager {
         lua.globals().set("config_info", config.clone())?;
 
         // auto-load library_dir
-        let library_dir = plugin_dir.join("core").to_str().unwrap();
+        let core_path = plugin_dir.join("core");
+        let library_dir = core_path.to_str().unwrap();
         lua.load(chunk!(package.path = $library_dir.."/?.lua"))
             .exec()?;
 


### PR DESCRIPTION
Quick fix to make the CLI compile again.

Line 99 in src/plugin/mod.rs had an issue with a variable not living long enough.