### PR TITLE
feat: add before_rebuild stage

### DIFF
--- a/docs/src/plugin/README.md
+++ b/docs/src/plugin/README.md
@@ -15,6 +15,7 @@ The plugin library have pre-define some important event you can control:
 - `build.on_start`
 - `build.on_finished`
 - `serve.on_start`
+- `serve.before_rebuild`
 - `serve.on_rebuild`
 - `serve.on_shutdown`
 
@@ -60,6 +61,12 @@ end
 manager.serve.on_start = function (info)
     -- this function will after clean & print to run, so you can print some thing.
     log.info("[plugin] Serve start: " .. info.name)
+end
+
+---@param info ServeRebuildInfo
+manager.serve.before_rebuild = function (info)
+    -- this function will execute before the CLI rebuilds
+    log.info("[plugin] Before rebuild: " .. info.name)
 end
 
 ---@param info ServeRebuildInfo

--- a/src/plugin/interface/mod.rs
+++ b/src/plugin/interface/mod.rs
@@ -167,6 +167,7 @@ impl<'lua> ToLua<'lua> for PluginBuildInfo<'lua> {
 #[derive(Debug, Clone, Default)]
 pub struct PluginServeInfo<'lua> {
     pub on_start: Option<Function<'lua>>,
+    pub before_rebuild: Option<Function<'lua>>,
     pub on_rebuild: Option<Function<'lua>>,
     pub on_shutdown: Option<Function<'lua>>,
 }
@@ -178,6 +179,9 @@ impl<'lua> FromLua<'lua> for PluginServeInfo<'lua> {
         if let mlua::Value::Table(tab) = lua_value {
             if let Ok(v) = tab.get::<_, Function>("on_start") {
                 res.on_start = Some(v);
+            }
+            if let Ok(v) = tab.get::<_, Function>("before_rebuild") {
+                res.before_rebuild = Some(v);
             }
             if let Ok(v) = tab.get::<_, Function>("on_rebuild") {
                 res.on_rebuild = Some(v);
@@ -198,7 +202,9 @@ impl<'lua> ToLua<'lua> for PluginServeInfo<'lua> {
         if let Some(v) = self.on_start {
             res.set("on_start", v)?;
         }
-
+        if let Some(v) = self.before_rebuild {
+            res.set("before_rebuild", v)?;
+        }
         if let Some(v) = self.on_rebuild {
             res.set("on_rebuild", v)?;
         }

--- a/src/plugin/interface/network.rs
+++ b/src/plugin/interface/network.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use mlua::{Error, UserData, UserDataMethods};
 
-use log::{error, info};
+use log::error;
 use reqwest::Url;
 use tokio::task;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -361,6 +361,11 @@ pub async fn startup_default(ip: String, port: u16, config: CrateConfig) -> Resu
         let config = watcher_config.clone();
         if let Ok(e) = info {
             if chrono::Local::now().timestamp() > last_update_time {
+                let _ = PluginManager::before_serve_rebuild(
+                    chrono::Local::now().timestamp(),
+                    e.paths.clone(),
+                );
+
                 match build_manager.rebuild() {
                     Ok(res) => {
                         last_update_time = chrono::Local::now().timestamp();


### PR DESCRIPTION
When using on_rebuild(), plugins that change files in the project will cause the CLI to reload, which causes the plugin to run again, which causes the CLI to rebuild again, and so on.

A quick solution is to add a stage where plugins can modify files before the CLI actually starts rebuilding the project.
This PR adds a `before_rebuild()` function, which is identical with `on_rebuild` but takes place before the rebuild.

Also removed an unused import in network.rs to make the compiler shut up. 