### PR TITLE
refactor: rename rebuild events

### DIFF
--- a/docs/src/plugin/README.md
+++ b/docs/src/plugin/README.md
@@ -15,8 +15,8 @@ The plugin library have pre-define some important event you can control:
 - `build.on_start`
 - `build.on_finished`
 - `serve.on_start`
-- `serve.before_rebuild`
-- `serve.on_rebuild`
+- `serve.on_rebuild_start`
+- `serve.on_rebuild_end`
 - `serve.on_shutdown`
 
 ### Plugin Template
@@ -64,13 +64,13 @@ manager.serve.on_start = function (info)
 end
 
 ---@param info ServeRebuildInfo
-manager.serve.before_rebuild = function (info)
+manager.serve.on_rebuild_start = function (info)
     -- this function will execute before the CLI rebuilds
     log.info("[plugin] Before rebuild: " .. info.name)
 end
 
 ---@param info ServeRebuildInfo
-manager.serve.on_rebuild = function (info)
+manager.serve.on_rebuild_end = function (info)
     -- this function will after clean & print to run, so you can print some thing.
     local files = plugin.tool.dump(info.changed_files)
     log.info("[plugin] Serve rebuild: '" .. files .. "'")

--- a/src/plugin/interface/mod.rs
+++ b/src/plugin/interface/mod.rs
@@ -167,8 +167,8 @@ impl<'lua> ToLua<'lua> for PluginBuildInfo<'lua> {
 #[derive(Debug, Clone, Default)]
 pub struct PluginServeInfo<'lua> {
     pub on_start: Option<Function<'lua>>,
-    pub before_rebuild: Option<Function<'lua>>,
-    pub on_rebuild: Option<Function<'lua>>,
+    pub on_rebuild_start: Option<Function<'lua>>,
+    pub on_rebuild_end: Option<Function<'lua>>,
     pub on_shutdown: Option<Function<'lua>>,
 }
 
@@ -180,11 +180,11 @@ impl<'lua> FromLua<'lua> for PluginServeInfo<'lua> {
             if let Ok(v) = tab.get::<_, Function>("on_start") {
                 res.on_start = Some(v);
             }
-            if let Ok(v) = tab.get::<_, Function>("before_rebuild") {
-                res.before_rebuild = Some(v);
+            if let Ok(v) = tab.get::<_, Function>("on_rebuild_start") {
+                res.on_rebuild_start = Some(v);
             }
-            if let Ok(v) = tab.get::<_, Function>("on_rebuild") {
-                res.on_rebuild = Some(v);
+            if let Ok(v) = tab.get::<_, Function>("on_rebuild_end") {
+                res.on_rebuild_end = Some(v);
             }
             if let Ok(v) = tab.get::<_, Function>("on_shutdown") {
                 res.on_shutdown = Some(v);
@@ -202,11 +202,11 @@ impl<'lua> ToLua<'lua> for PluginServeInfo<'lua> {
         if let Some(v) = self.on_start {
             res.set("on_start", v)?;
         }
-        if let Some(v) = self.before_rebuild {
-            res.set("before_rebuild", v)?;
+        if let Some(v) = self.on_rebuild_start {
+            res.set("on_rebuild_start", v)?;
         }
-        if let Some(v) = self.on_rebuild {
-            res.set("on_rebuild", v)?;
+        if let Some(v) = self.on_rebuild_end {
+            res.set("on_rebuild_end", v)?;
         }
 
         if let Some(v) = self.on_shutdown {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -312,7 +312,7 @@ impl PluginManager {
             let info = manager.get::<i32, PluginInfo>(i)?;
             lua.globals()
                 .set("_temp_plugin_dir", info.inner.plugin_dir.clone())?;
-            if let Some(func) = info.serve.before_rebuild {
+            if let Some(func) = info.serve.on_rebuild_start {
                 func.call::<Table, ()>(args.clone())?;
             }
         }
@@ -337,7 +337,7 @@ impl PluginManager {
             let info = manager.get::<i32, PluginInfo>(i)?;
             lua.globals()
                 .set("_temp_plugin_dir", info.inner.plugin_dir.clone())?;
-            if let Some(func) = info.serve.on_rebuild {
+            if let Some(func) = info.serve.on_rebuild_end {
                 func.call::<Table, ()>(args.clone())?;
             }
         }


### PR DESCRIPTION
`before_rebuild` takes place before the rebuild, so it becomes `on_rebuild_start`
`on_rebuild` actually takes place after the rebuild so we should call it `on_rebuild_end`